### PR TITLE
Add catch-all NotFound route

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -60,6 +60,10 @@ const router = createBrowserRouter([
         path: 'account',
         element: <Account />,
       },
+      {
+        path: '*',
+        element: <NotFound />,
+      },
     ],
   },
 ]);


### PR DESCRIPTION
## Summary
- ensure unknown routes show NotFound page by adding a `*` catch-all

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688322615e08832d95244e2806c2c202